### PR TITLE
Rename the package from `LSFClusterManager.jl` to `LSFClusterManagers.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "LSFClusterManager"
+name = "LSFClusterManagers"
 uuid = "af02cf76-cbe3-4eeb-96a8-af9391005858"
 version = "1.0.0-DEV"
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# LSFClusterManager.jl
+# LSFClusterManagers.jl
 
-The `LSFClusterManager.jl` package implements code for the LSF (Load Sharing Facility) compute cluster job queue system.
+The `LSFClusterManagers.jl` package implements code for the LSF (Load Sharing Facility) compute cluster job queue system.
 
-`LSFClusterManager.LSFManager` supports IBM's scheduler.  See the `addprocs_lsf` docstring
+`LSFClusterManagers.LSFManager` supports IBM's scheduler.  See the `addprocs_lsf` docstring
 for more information.
 
-Implemented in this package (the `LSFClusterManager.jl` package):
+Implemented in this package (the `LSFClusterManagers.jl` package):
 
 | Job queue system | Command to add processors |
 | ---------------- | ------------------------- |
-| Load Sharing Facility (LSF) | `addprocs_lsf(np::Integer; bsub_flags=``, ssh_cmd=``)` or `addprocs(LSFClusterManager.LSFManager(np, bsub_flags, ssh_cmd, retry_delays, throttle))` |
+| Load Sharing Facility (LSF) | `addprocs_lsf(np::Integer; bsub_flags=``, ssh_cmd=``)` or `addprocs(LSFClusterManagers.LSFManager(np, bsub_flags, ssh_cmd, retry_delays, throttle))` |

--- a/src/LSFClusterManagers.jl
+++ b/src/LSFClusterManagers.jl
@@ -1,4 +1,4 @@
-module LSFClusterManager
+module LSFClusterManagers
 
 using Distributed
 using Sockets

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-import LSFClusterManager
+import LSFClusterManagers
 import Test
 
 import Distributed
@@ -11,7 +11,7 @@ using Distributed: remotecall_fetch, @spawnat
 using Test: @testset, @test, @test_skip
 
 # LSF:
-using LSFClusterManager: addprocs_lsf, LSFManager
+using LSFClusterManagers: addprocs_lsf, LSFManager
 
 const test_args = lowercase.(strip.(ARGS))
 
@@ -19,7 +19,7 @@ const test_args = lowercase.(strip.(ARGS))
 
 lsf_is_installed() = !isnothing(Sys.which("bsub"))
 
-@testset "LSFClusterManager.jl" begin
+@testset "LSFClusterManagers.jl" begin
     if lsf_is_installed()
         @info "Running the LSF tests..." Sys.which("bsub")
         include("lsf.jl")


### PR DESCRIPTION
Ref #5.

I think the name of this package should probably be pluralized, based on the [package naming guidelines here](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules):

> Packages that provide most of their functionality in association with a new type should have pluralized names.